### PR TITLE
Set device as HeaterCooler instead of Thermostat.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio');
 const rp = require('request-promise-native');
 
 var Service;

--- a/index.js
+++ b/index.js
@@ -210,9 +210,9 @@ class Thermostat {
         return callback(new Error('Modlet broken.'));
       }
 
-      this.api.log(this.name, 'set heating / cooling active: ' + !this.powerOn);
+      this.api.log(this.name, 'set heating / cooling active: ' + value);
 
-      this.powerOn = !this.powerOn;
+      this.powerOn = value;
       this.update().then(() => callback());
     })();
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/dave-atx/homebridge-platform-smartac#readme",
   "dependencies": {
-    "cheerio": "^0.22.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5"
   },


### PR DESCRIPTION
Thanks for the fantastic plugin!!

I wanted to be able to tap the accessory in the Home app in order to turn on & off my air conditioner. Switching the service to be a [`HeaterCooler`](https://github.com/KhaosT/HAP-NodeJS/blob/a4f806d4eccf97cbb4995207e3225937b7622519/lib/gen/HomeKitTypes.js#L2990-L3007) seems to have done the trick.

After swapping that, I was also able to toggle the "state" from `COOLING` to `IDLE` based on whether the thermometer read lower than the target, so that the app would show the correct icon and verb:

<img width="302" src="https://user-images.githubusercontent.com/583202/41755755-eb17eb10-75a6-11e8-88a2-6c2d78f29458.jpeg">